### PR TITLE
security: migrate upload-pages-artifact to patched Contrast fork

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -26,7 +26,7 @@ jobs:
         shell: pwsh
 
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: Contrast-Security-OSS/upload-pages-artifact@24d45ff20bb020d94ec2d54d80dc54920f42eff8 # v3.0.1
         with:
           path: ./dist
   publish:


### PR DESCRIPTION
## Summary

Migrate `actions/upload-pages-artifact` to our internal security-patched fork.

The upstream action introduced a CMD_EXEC vulnerability via `${{{{ inputs.include-hidden-files }}}}` directly interpolated in `run:` blocks. The Contrast fork fixes this with env var indirection.

**Fixed SHA:** `24d45ff20bb020d94ec2d54d80dc54920f42eff8`
**Fork:** https://github.com/Contrast-Security-OSS/upload-pages-artifact
**Upstream fix PR:** actions/upload-pages-artifact#141

🤖 Generated with [Claude Code](https://claude.com/claude-code)